### PR TITLE
charts: add tolerations

### DIFF
--- a/charts/templates/templates/webhook.yaml
+++ b/charts/templates/templates/webhook.yaml
@@ -23,6 +23,9 @@ spec:
       {{- with .Values.webhook.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.webhook.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.webhook.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/templates/values.yaml
+++ b/charts/templates/values.yaml
@@ -13,6 +13,7 @@ webhook:
   envs:
     LEGO_DISABLE_CNAME_SUPPORT: 'true'
   nodeSelector: { }
+  tolerations: [ ]
   extraArgs: [ ]
 
 certManager:


### PR DESCRIPTION
Add tolerations field for the pod (configurable via values.yaml).
Needed to allow deployment on restricted nodes.