### PR TITLE
Add support for configuring Pod dnsConfig

### DIFF
--- a/charts/templates/templates/webhook.yaml
+++ b/charts/templates/templates/webhook.yaml
@@ -26,6 +26,10 @@ spec:
       {{- with .Values.webhook.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.webhook.dnsConfig }}
+      dnsPolicy: None
+      dnsConfig: {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "appname" . }}
           image: '{{ .Values.webhook.image.repository }}:{{ default (printf "v%s" .Chart.Version) .Values.webhook.image.tag }}'

--- a/charts/templates/values.yaml
+++ b/charts/templates/values.yaml
@@ -14,6 +14,8 @@ webhook:
     LEGO_DISABLE_CNAME_SUPPORT: 'true'
   nodeSelector: { }
   extraArgs: [ ]
+  dnsConfig: { }
+  
 
 certManager:
   namespace: ''


### PR DESCRIPTION
This change adds the possibility to define a custom dnsConfig for the Pod.
This is particularly useful in split-DNS environments, where different DNS servers are required to resolve internal domains.
A common use case is issuing TLS certificates for in-house domains that are only resolvable via internal DNS.